### PR TITLE
fix: search ads will crash when clicking on it

### DIFF
--- a/android/src/main/kotlin/com/example/flutter_custom_search_ads/FlutterCustomSearchAdsPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_custom_search_ads/FlutterCustomSearchAdsPlugin.kt
@@ -4,8 +4,12 @@ import androidx.annotation.NonNull
 import com.example.flutter_custom_search_ads.UI.CustomSearchAdsViewFactory
 import com.example.flutter_custom_search_ads.classes.AdInstanceManager
 import io.flutter.Log
+import io.flutter.embedding.android.FlutterActivity
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.embedding.engine.plugins.activity.ActivityAware
+import io.flutter.embedding.engine.plugins.activity.ActivityPluginBinding
+import io.flutter.plugin.common.BinaryMessenger
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
@@ -16,21 +20,19 @@ import kotlin.math.log
 var adInstanceManager: AdInstanceManager? = null
 
 /** FlutterCustomSearchAdsPlugin */
-class FlutterCustomSearchAdsPlugin: FlutterPlugin, MethodCallHandler {
+class FlutterCustomSearchAdsPlugin: FlutterPlugin, MethodCallHandler, ActivityAware {
   private lateinit var channel : MethodChannel
+  private lateinit var activity: FlutterActivity
+  private lateinit var binaryMessenger: BinaryMessenger
 
   override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) {
-      flutterPluginBinding.platformViewRegistry.registerViewFactory("customSearchAds", CustomSearchAdsViewFactory())
-
-      channel = MethodChannel(flutterPluginBinding.binaryMessenger, "plugins.dessonchan.com/flutter-custom-search-ads")
-      channel.setMethodCallHandler(this)
-
-      adInstanceManager = AdInstanceManager(channel, flutterPluginBinding.applicationContext)
+    binaryMessenger = flutterPluginBinding.binaryMessenger
+    flutterPluginBinding.platformViewRegistry.registerViewFactory("customSearchAds", CustomSearchAdsViewFactory())
   }
 
   override fun onMethodCall(call: MethodCall, result: Result) {
     if (call.method == "onAdLoad") {
-      var adId = call.argument<Int>("adId")
+      val adId = call.argument<Int>("adId")
       if (adId != null) {
         adInstanceManager?.loadAd(adId, call.arguments as Map<String, Any>)
         result.success("")
@@ -42,5 +44,27 @@ class FlutterCustomSearchAdsPlugin: FlutterPlugin, MethodCallHandler {
 
   override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
     channel.setMethodCallHandler(null)
+  }
+
+  /**
+   * Since
+   */
+  override fun onAttachedToActivity(binding: ActivityPluginBinding) {
+    activity = binding.activity as FlutterActivity
+    channel = MethodChannel(binaryMessenger, "plugins.dessonchan.com/flutter-custom-search-ads")
+    channel.setMethodCallHandler(this)
+    adInstanceManager = AdInstanceManager(channel, activity)
+  }
+
+  override fun onDetachedFromActivityForConfigChanges() {
+
+  }
+
+  override fun onReattachedToActivityForConfigChanges(binding: ActivityPluginBinding) {
+
+  }
+
+  override fun onDetachedFromActivity() {
+
   }
 }

--- a/android/src/main/kotlin/com/example/flutter_custom_search_ads/FlutterCustomSearchAdsPlugin.kt
+++ b/android/src/main/kotlin/com/example/flutter_custom_search_ads/FlutterCustomSearchAdsPlugin.kt
@@ -47,7 +47,9 @@ class FlutterCustomSearchAdsPlugin: FlutterPlugin, MethodCallHandler, ActivityAw
   }
 
   /**
-   * Since
+   * Since search ad needs an activity instance of context
+   * we can get the activity by implementing ActivityAware
+   * https://stackoverflow.com/questions/59887901/get-activity-reference-in-flutter-plugin
    */
   override fun onAttachedToActivity(binding: ActivityPluginBinding) {
     activity = binding.activity as FlutterActivity

--- a/android/src/main/kotlin/com/example/flutter_custom_search_ads/classes/AdInstanceManager.kt
+++ b/android/src/main/kotlin/com/example/flutter_custom_search_ads/classes/AdInstanceManager.kt
@@ -6,6 +6,7 @@ import java.util.*
 
 import com.example.flutter_custom_search_ads.classes.CustomSearchAd
 import com.google.android.gms.ads.AdListener
+import io.flutter.embedding.android.FlutterActivity
 
 class AdInstanceManager(channel: MethodChannel, context: Context) {
     var context: Context
@@ -61,5 +62,9 @@ class AdInstanceManager(channel: MethodChannel, context: Context) {
 
     fun onAdWillDismissScreen(ad: CustomSearchAd) {
         channel.invokeMethod("onAdWillDismissScreen", mapOf<String, Any>(Pair("adId", ad.adId)))
+    }
+
+    fun onAdClicked(ad: CustomSearchAd) {
+        channel.invokeMethod("onAdClicked", mapOf<String, Any>(Pair("adId", ad.adId)))
     }
 }

--- a/android/src/main/kotlin/com/example/flutter_custom_search_ads/classes/AdInstanceManager.kt
+++ b/android/src/main/kotlin/com/example/flutter_custom_search_ads/classes/AdInstanceManager.kt
@@ -8,19 +8,11 @@ import com.example.flutter_custom_search_ads.classes.CustomSearchAd
 import com.google.android.gms.ads.AdListener
 import io.flutter.embedding.android.FlutterActivity
 
-class AdInstanceManager(channel: MethodChannel, context: Context) {
-    var context: Context
-    private var channel: MethodChannel
-    var loadedAds: MutableMap<Int, CustomSearchAd>
-
-    init {
-        this.context = context
-        this.channel = channel
-        loadedAds = mutableMapOf<Int, CustomSearchAd>()
-    }
+class AdInstanceManager(val channel: MethodChannel, val context: Context) {
+    var loadedAds: MutableMap<Int, CustomSearchAd> = mutableMapOf<Int, CustomSearchAd>()
 
     fun loadAd(adId: Int, arguments:Map<String, Any>) {
-        var ad = CustomSearchAd(this, adId,
+        val ad = CustomSearchAd(this, adId,
             arguments["adUnitId"] as String,
             arguments["query"] as String,
             arguments["testAd"] as Boolean,

--- a/android/src/main/kotlin/com/example/flutter_custom_search_ads/classes/CustomSearchAd.kt
+++ b/android/src/main/kotlin/com/example/flutter_custom_search_ads/classes/CustomSearchAd.kt
@@ -6,51 +6,31 @@ import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.search.DynamicHeightSearchAdRequest
 import com.google.android.gms.ads.search.SearchAdView
 
-
-class CustomSearchAd(manager: AdInstanceManager,
-                     adId: Int,
-                     adUnitId: String,
-                     query:String,
-                     testAd: Boolean = false,
-                     channel:String,
-                     styleId: String
+class CustomSearchAd(val manager: AdInstanceManager,
+                     val adId: Int,
+                     val adUnitId: String,
+                     val query: String,
+                     val testAd: Boolean = false,
+                     val channel:String,
+                     val styleId: String
 ): AdListener() {
 
-    var manager: AdInstanceManager
-    var searchBanner: SearchAdView
-
-    var adId: Int
-    var adUnitId: String
-    var query: String
-    var testAd: Boolean
-    var channel: String
-    var styleId: String
+    var searchBanner: SearchAdView = SearchAdView(manager.context)
 
     init {
-        this.manager = manager
-
-        this.adId = adId
-        this.adUnitId = adUnitId
-        this.query = query
-        this.testAd = testAd
-        this.channel = channel
-        this.styleId = styleId
-
-        this.searchBanner = SearchAdView(manager.context)
-        this.searchBanner.setAdSize(AdSize.SEARCH)
-        this.searchBanner.adListener = this
+        searchBanner.setAdSize(AdSize.SEARCH)
+        searchBanner.adListener = this
     }
 
     fun load() {
-        this.searchBanner.adUnitId = adUnitId
-        var request = DynamicHeightSearchAdRequest.Builder()
+        searchBanner.adUnitId = adUnitId
+        val request = DynamicHeightSearchAdRequest.Builder()
         request.setQuery(query)
         request.setAdTest(testAd)
         request.setChannel(channel)
         request.setNumber(1)
         request.setAdvancedOptionValue("csa_styleId", styleId)
-
-        this.searchBanner.loadAd(request.build())
+        searchBanner.loadAd(request.build())
     }
 
     override fun onAdLoaded() {
@@ -65,12 +45,12 @@ class CustomSearchAd(manager: AdInstanceManager,
 
     override fun onAdOpened() {
         super.onAdOpened()
-        manager.onAdPresent(this)
+        manager.onAdOpen(this)
     }
 
     override fun onAdClicked() {
         super.onAdClicked()
-        manager.onAdOpen(this)
+        manager.onAdClicked(this)
     }
 
     override fun onAdClosed() {


### PR DESCRIPTION
```
[        ] E/AndroidRuntime(26958): android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag. Is this really what you want?
[        ] E/AndroidRuntime(26958): 	at android.app.ContextImpl.startActivity(ContextImpl.java:1080)
[        ] E/AndroidRuntime(26958): 	at android.app.ContextImpl.startActivity(ContextImpl.java:1056)
[        ] E/AndroidRuntime(26958): 	at android.content.ContextWrapper.startActivity(ContextWrapper.java:411)
[        ] E/AndroidRuntime(26958): 	at com.google.android.gms.ads.internal.n.shouldOverrideUrlLoading(:com.google.android.gms.policy_ads_fdr_dynamite@221908400@221908400057.447330857.447330857:29)
[        ] E/AndroidRuntime(26958): 	at android.webkit.WebViewClient.shouldOverrideUrlLoading(WebViewClient.java:83)
[        ] E/AndroidRuntime(26958): 	at org.chromium.android_webview.AwContentsClientBridge.shouldOverrideUrlLoading(chromium-TrichromeWebViewGoogle6432.aab-stable-506012934:46)
[        ] E/AndroidRuntime(26958): 	at android.os.MessageQueue.nativePollOnce(Native Method)
[        ] E/AndroidRuntime(26958): 	at android.os.MessageQueue.next(MessageQueue.java:338)
[        ] E/AndroidRuntime(26958): 	at android.os.Looper.loopOnce(Looper.java:301)
[        ] E/AndroidRuntime(26958): 	at android.os.Looper.loop(Looper.java:475)
[        ] E/AndroidRuntime(26958): 	at android.app.ActivityThread.main(ActivityThread.java:7889)
[        ] E/AndroidRuntime(26958): 	at java.lang.reflect.Method.invoke(Native Method)
[        ] E/AndroidRuntime(26958): 	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:548)
[        ] E/AndroidRuntime(26958): 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1009)
```
solution:
https://groups.google.com/g/google-admob-ads-sdk/c/kaFSY0z6in0/m/5Jb6DJZUBZMJ
https://stackoverflow.com/questions/59887901/get-activity-reference-in-flutter-plugin